### PR TITLE
Refactores the GLOBALS.context to use more expressive naming

### DIFF
--- a/app/Game/Core/GameController.js
+++ b/app/Game/Core/GameController.js
@@ -1,11 +1,11 @@
 define([
-    "Game/" + GLOBALS.context + "/Physics/Engine",
-    "Game/" + GLOBALS.context + "/Loader/TiledLevel",
-    "Game/" + GLOBALS.context + "/Player",
+    "Game/" + App.context + "/Physics/Engine",
+    "Game/" + App.context + "/Loader/TiledLevel",
+    "Game/" + App.context + "/Player",
     "Lib/Utilities/NotificationCenter",
-    "Game/" + GLOBALS.context + "/GameObjects/Doll",
-    "Game/" + GLOBALS.context + "/GameObjects/GameObject",
-    "Game/" + GLOBALS.context + "/GameObjects/Item",
+    "Game/" + App.context + "/GameObjects/Doll",
+    "Game/" + App.context + "/GameObjects/GameObject",
+    "Game/" + App.context + "/GameObjects/Item",
     "Lib/Utilities/Assert",
 ],
 

--- a/app/Game/Core/GameObjects/Doll.js
+++ b/app/Game/Core/GameObjects/Doll.js
@@ -1,10 +1,10 @@
 define([
-    "Game/" + GLOBALS.context + "/GameObjects/GameObject",
+    "Game/" + App.context + "/GameObjects/GameObject",
     "Lib/Utilities/Exception",
     "Lib/Vendor/Box2D", 
     "Game/Config/Settings", 
-    "Game/" + GLOBALS.context + "/Collision/Detector",
-    "Game/" + GLOBALS.context + "/GameObjects/Item",
+    "Game/" + App.context + "/Collision/Detector",
+    "Game/" + App.context + "/GameObjects/Item",
     "Lib/Utilities/NotificationCenter",
     "Lib/Utilities/Assert"
 ], 

--- a/app/Game/Core/GameObjects/Item.js
+++ b/app/Game/Core/GameObjects/Item.js
@@ -1,5 +1,5 @@
 define([
-	"Game/" + GLOBALS.context + "/GameObjects/GameObject",
+	"Game/" + App.context + "/GameObjects/GameObject",
 	"Lib/Vendor/Box2D",
     "Lib/Utilities/OptionsHelper",
 	"Game/Config/Settings",

--- a/app/Game/Core/GameObjects/Items/RagDoll.js
+++ b/app/Game/Core/GameObjects/Items/RagDoll.js
@@ -1,5 +1,5 @@
 define([
-	"Game/" + GLOBALS.context + "/GameObjects/Item",
+	"Game/" + App.context + "/GameObjects/Item",
 	"Lib/Vendor/Box2D",
 	"Game/Config/Settings",
     "Lib/Utilities/NotificationCenter",

--- a/app/Game/Core/GameObjects/Items/RagDoll2.js
+++ b/app/Game/Core/GameObjects/Items/RagDoll2.js
@@ -1,5 +1,5 @@
 define([
-	"Game/" + GLOBALS.context + "/GameObjects/Item",
+	"Game/" + App.context + "/GameObjects/Item",
 	"Lib/Vendor/Box2D",
 	"Game/Config/Settings"
 ],

--- a/app/Game/Core/GameObjects/Items/RubeDoll.js
+++ b/app/Game/Core/GameObjects/Items/RubeDoll.js
@@ -1,5 +1,5 @@
 define([
-    "Game/" + GLOBALS.context + "/GameObjects/Item",
+    "Game/" + App.context + "/GameObjects/Item",
     "Lib/Vendor/RubeLoader",
     "Lib/Vendor/Box2D",
     "Game/Config/Settings",

--- a/app/Game/Core/GameObjects/Items/Skateboard.js
+++ b/app/Game/Core/GameObjects/Items/Skateboard.js
@@ -1,5 +1,5 @@
 define([
-	"Game/" + GLOBALS.context + "/GameObjects/Item",
+	"Game/" + App.context + "/GameObjects/Item",
 	"Lib/Vendor/Box2D",
 	"Game/Config/Settings",
     "Lib/Utilities/Assert"
@@ -89,7 +89,7 @@ function (Parent, Box2D, Settings, Assert) {
 
 /*
 define([
-    "Game/" + GLOBALS.context + "/GameObjects/Item",
+    "Game/" + App.context + "/GameObjects/Item",
     "Lib/Vendor/Box2D",
     "Game/Config/Settings",
     "Lib/Utilities/Assert"

--- a/app/Game/Core/GameObjects/SpectatorDoll.js
+++ b/app/Game/Core/GameObjects/SpectatorDoll.js
@@ -1,5 +1,5 @@
 define([
-    "Game/" + GLOBALS.context + "/GameObjects/GameObject",
+    "Game/" + App.context + "/GameObjects/GameObject",
     "Lib/Vendor/Box2D"
 ], 
  

--- a/app/Game/Core/GameObjects/Tile.js
+++ b/app/Game/Core/GameObjects/Tile.js
@@ -1,5 +1,5 @@
 define([
-	"Game/" + GLOBALS.context + "/GameObjects/GameObject",
+	"Game/" + App.context + "/GameObjects/GameObject",
 	"Lib/Vendor/Box2D",
 	"Game/Config/Settings",
     "Lib/Utilities/Exception",

--- a/app/Game/Core/Loader/Level.js
+++ b/app/Game/Core/Loader/Level.js
@@ -3,12 +3,12 @@ define([
     "Lib/Vendor/Box2D",
     "Lib/Utilities/NotificationCenter",
     "Lib/Utilities/Abstract",
-    "Game/" + GLOBALS.context + "/Collision/Detector",
-    "Game/" + GLOBALS.context + "/GameObjects/Tile",
-    "Game/" + GLOBALS.context + "/GameObjects/Item",
-    "Game/" + GLOBALS.context + "/GameObjects/Items/Skateboard",
-    "Game/" + GLOBALS.context + "/GameObjects/Items/RagDoll",
-    "Game/" + GLOBALS.context + "/GameObjects/Items/RubeDoll"
+    "Game/" + App.context + "/Collision/Detector",
+    "Game/" + App.context + "/GameObjects/Tile",
+    "Game/" + App.context + "/GameObjects/Item",
+    "Game/" + App.context + "/GameObjects/Items/Skateboard",
+    "Game/" + App.context + "/GameObjects/Items/RagDoll",
+    "Game/" + App.context + "/GameObjects/Items/RubeDoll"
 
 ], function (Settings, Box2D, nc, Abstract, CollisionDetector, Tile, Item, Skateboard, RagDoll, RubeDoll) {
     

--- a/app/Game/Core/Loader/TiledLevel.js
+++ b/app/Game/Core/Loader/TiledLevel.js
@@ -1,5 +1,5 @@
 define([
-    "Game/" + GLOBALS.context + "/Loader/Level",
+    "Game/" + App.context + "/Loader/Level",
     "Game/Config/Settings", 
     "Game/Config/ItemSettings",
     "Lib/Vendor/Box2D", 
@@ -8,10 +8,10 @@ define([
     "Lib/Utilities/NotificationCenter",
     "Lib/Utilities/Assert",
     "Game/Client/View/Abstract/Layer", 
-    "Game/" + GLOBALS.context + "/Collision/Detector",
-    "Game/" + GLOBALS.context + "/GameObjects/Tile",
-    "Game/" + GLOBALS.context + "/GameObjects/Item",
-    "Game/" + GLOBALS.context + "/GameObjects/Items/Skateboard",
+    "Game/" + App.context + "/Collision/Detector",
+    "Game/" + App.context + "/GameObjects/Tile",
+    "Game/" + App.context + "/GameObjects/Item",
+    "Game/" + App.context + "/GameObjects/Items/Skateboard",
 
 ], function (Parent, Settings, ItemSettings, Box2D, optionsHelper, Exception, nc, Assert, AbstractLayer, CollisionDetector, Tile, Item, Skateboard) {
     

--- a/app/Game/Core/Physics/Engine.js
+++ b/app/Game/Core/Physics/Engine.js
@@ -1,7 +1,7 @@
 define([
     "Game/Config/Settings",
     "Lib/Vendor/Box2D",
-    "Game/" + GLOBALS.context + "/Collision/Detector",
+    "Game/" + App.context + "/Collision/Detector",
     "Lib/Utilities/NotificationCenter"
 ],
 

--- a/app/Game/Core/Player.js
+++ b/app/Game/Core/Player.js
@@ -1,12 +1,12 @@
 define([
-    "Game/" + GLOBALS.context + "/GameObjects/Doll",
-    "Game/" + GLOBALS.context + "/Control/PlayerController",
+    "Game/" + App.context + "/GameObjects/Doll",
+    "Game/" + App.context + "/Control/PlayerController",
     "Game/Config/Settings",
     "Lib/Utilities/NotificationCenter",
     "Lib/Utilities/Exception",
     "Lib/Utilities/ColorConverter",
-    "Game/" + GLOBALS.context + "/GameObjects/SpectatorDoll",
-    "Game/" + GLOBALS.context + "/GameObjects/Items/RubeDoll"
+    "Game/" + App.context + "/GameObjects/SpectatorDoll",
+    "Game/" + App.context + "/GameObjects/Items/RubeDoll"
 ],
 
 function (Doll, PlayerController, Settings, nc, Exception, ColorConverter, SpectatorDoll, RubeDoll) {

--- a/channel.js
+++ b/channel.js
@@ -1,4 +1,7 @@
-GLOBALS = { context: "Channel" };
+// "use strict"; intentionally omitted as App scope workaround
+
+Error.stackTraceLimit = Infinity;
+
 var requirejs = require('requirejs');
 
 requirejs.config({
@@ -11,14 +14,17 @@ requirejs.config({
     },
 });
 
-var inspector = {};
+
+App = {};
+App.inspector = {};
+App.context = "Channel";
 
 requirejs([
     "Game/Channel/PipeToServer"
-], 
+],
 
 function (PipeToServer) {
 	var PipeToServer = new PipeToServer(process);
     
-    inspector.PipeToServer = PipeToServer;
+    App.inspector.PipeToServer = PipeToServer;
 });

--- a/client.js
+++ b/client.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var GLOBALS = { context: "Client" };
+Error.stackTraceLimit = Infinity;
 
 requirejs.config({
     baseUrl: 'app',
@@ -15,8 +15,9 @@ requirejs.config({
     },
 });
 
-if(!Chuck) var Chuck = {};
-Chuck.inspector = {};
+var App = App || {};
+App.inspector = {};
+App.context = "Client";
 
 requirejs([
     "Game/Client/Networker", 
@@ -42,10 +43,10 @@ function (Networker, SocketIO, Settings, Exception, nc, Menu) {
         };
         var socket = SocketIO.connect("/", options);
         var networker = new Networker(socket, channelName, nickname);
-        Chuck.inspector.networker = networker;
-        Chuck.inspector.settings = Settings;
-        Chuck.inspector.nc = nc;
-        Chuck.inspector.resetLevel = function() { networker.sendGameCommand("resetLevel"); } 
+        App.inspector.networker = networker;
+        App.inspector.settings = Settings;
+        App.inspector.nc = nc;
+        App.inspector.resetLevel = function() { networker.sendGameCommand("resetLevel"); } 
     }
     menu.init();
 });

--- a/config/build-profile.js
+++ b/config/build-profile.js
@@ -10,7 +10,7 @@
     name: "../client",
     out: "../build/client.min.js",
     onBuildRead: function (moduleName, path, contents) {
-        var contents = contents.replace(/\" \+ GLOBALS.context \+ \"/g, "Client");
+        var contents = contents.replace(/\" \+ App.context \+ \"/g, "Client");
         return contents;
     }
 })

--- a/server.js
+++ b/server.js
@@ -1,10 +1,13 @@
 "use strict"
 
-var GLOBALS = { context: "Channel" };
+Error.stackTraceLimit = Infinity;
+
 var requirejs = require('requirejs');
 var fs = require('fs');
 
-var inspector;
+var App = App || {};
+App.inspector = {};
+App.context = "Channel";
 
 requirejs.config({
     nodeRequire: require,
@@ -41,11 +44,11 @@ function (HttpServer, Socket, Coordinator, Settings) {
     var httpServer = new HttpServer(options, coordinator);
     var socket = new Socket(httpServer.getServer(), options, coordinator);
 
-    inspector = {
+    App.inspector = {
         coordinator: coordinator,
         httpServer: httpServer,
         socket: socket
     }
 });
 
-exports = module.exports = inspector;
+exports = module.exports = App;


### PR DESCRIPTION
Combines GLOBALS and Chuck namespace into App. Also increases
number of stack trace steps to be printed when an error occurs.

I experimented with the "replace" plugin from require.js, which
works but it would mean that our context switchable
"import-statements" would look like the example below, which I
decided against at least for now, just because of the looks.

The downside of not using the plugin is that we cannot use the
"use strict" statement in the channel.js entry script and also
cannot put a "var" in front of App variable there.

For example: "replace!Game/:AppContext/Physics/Engine",
Instead of:  "Game/" + App.context + "/Physics/Engine",

Fixes #86
